### PR TITLE
Make_unique function is added

### DIFF
--- a/include/kora/utility.hpp
+++ b/include/kora/utility.hpp
@@ -31,5 +31,6 @@ along with this program. If not, see <http://www.gnu.org/licenses/>.
 #include "kora/utility/type_traits.hpp"
 #include "kora/utility/underlying_type.hpp"
 #include "kora/utility/visibility.hpp"
+#include "kora/utility/make_unique.hpp"
 
 #endif

--- a/include/kora/utility/make_unique.hpp
+++ b/include/kora/utility/make_unique.hpp
@@ -48,25 +48,28 @@ struct is_array_of_known_bound<T[N]> : std::true_type {};
 
 } // namespace detail
 
-//! This function shall not participate in overload resolution unless T is not an array.
+//! Constructs a non-array type T. The arguments are passed to the constructor of T.
+//! The function does not participate in the overload resolution if T is an array type.
 //! \param args list of arguments with which an instance of T will be constructed
-//! \return std::unique_ptr<T>(new T(std::forward<Args>(args)...))
+//! \returns std::unique_ptr<T>(new T(std::forward<Args>(args)...))
 template<typename T, typename... Args>
 typename std::enable_if<!std::is_array<T>::value, std::unique_ptr<T>>::type
 make_unique(Args&&... args) {
     return std::unique_ptr<T>(new T(std::forward<Args>(args)...));
 }
 
-//! This function shall not participate in overload resolution unless T is an array of unknown bound.
+//! Constructs an array of unknown bound T.
+//! The function does not participate in the overload resolution unless T is an array of unknown bound.
 //! \param size the size of the array to construct
-//! return std::unique_ptr<T>(new typename std::remove_extent<T>::type[size]())
+//! returns std::unique_ptr<T>(new typename std::remove_extent<T>::type[size]())
 template<typename T>
 typename std::enable_if<detail::is_array_of_unknown_bound<T>::value, std::unique_ptr<T>>::type
 make_unique(std::size_t size) {
     return std::unique_ptr<T>(new typename std::remove_extent<T>::type[size]());
 }
 
-//! This function shall not participate in overload resolution unless T is an array of known bound.
+//! Construction of arrays of known bound is disallowed.
+//! The function does not participate in the overload resolution unless T is an array of known bound.
 template<typename T, typename... Args>
 typename std::enable_if<detail::is_array_of_known_bound<T>::value>::type
 make_unique(Args&&...) = delete;

--- a/include/kora/utility/make_unique.hpp
+++ b/include/kora/utility/make_unique.hpp
@@ -1,0 +1,76 @@
+/*
+Copyright (c) 2014 Artem Sokolov <derikon@yandex.ru>
+Copyright (c) 2011-2014 Other contributors as noted in the AUTHORS file.
+
+This file is part of Kora.
+
+Kora is free software; you can redistribute it and/or modify
+it under the terms of the GNU Lesser General Public License as published by
+the Free Software Foundation; either version 3 of the License, or
+(at your option) any later version.
+
+Kora is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+GNU Lesser General Public License for more details.
+
+You should have received a copy of the GNU Lesser General Public License
+along with this program. If not, see <http://www.gnu.org/licenses/>.
+*/
+
+#ifndef KORA_UTILITY_MAKE_UNIQUE_HPP
+#define KORA_UTILITY_MAKE_UNIQUE_HPP
+
+#include <memory>
+#include <type_traits>
+
+namespace kora {
+
+namespace detail {
+
+template<typename T>
+struct is_array_of_unknown_bound : std::false_type {};
+
+template<typename T>
+struct is_array_of_unknown_bound<T[]> : std::true_type {};
+
+template<typename T, std::size_t N>
+struct is_array_of_unknown_bound<T[N]> : std::false_type {};
+
+template<typename T>
+struct is_array_of_known_bound : std::false_type {};
+
+template<typename T>
+struct is_array_of_known_bound<T[]> : std::false_type {};
+
+template<typename T, std::size_t N>
+struct is_array_of_known_bound<T[N]> : std::true_type {};
+
+} // namespace detail
+
+//! This function shall not participate in overload resolution unless T is not an array.
+//! \param args list of arguments with which an instance of T will be constructed
+//! \return std::unique_ptr<T>(new T(std::forward<Args>(args)...))
+template<typename T, typename... Args>
+typename std::enable_if<!std::is_array<T>::value, std::unique_ptr<T>>::type
+make_unique(Args&&... args) {
+    return std::unique_ptr<T>(new T(std::forward<Args>(args)...));
+}
+
+//! This function shall not participate in overload resolution unless T is an array of unknown bound.
+//! \param size the size of the array to construct
+//! return std::unique_ptr<T>(new typename std::remove_extent<T>::type[size]())
+template<typename T>
+typename std::enable_if<detail::is_array_of_unknown_bound<T>::value, std::unique_ptr<T>>::type
+make_unique(std::size_t size) {
+    return std::unique_ptr<T>(new typename std::remove_extent<T>::type[size]());
+}
+
+//! This function shall not participate in overload resolution unless T is an array of known bound.
+template<typename T, typename... Args>
+typename std::enable_if<detail::is_array_of_known_bound<T>::value>::type
+make_unique(Args&&...) = delete;
+
+} // namespace kora
+
+#endif

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -29,6 +29,7 @@ ADD_EXECUTABLE(kora-tests
     dynamic/json
     dynamic/object
     utility/lazy_false
+    utility/make_unique
     utility/noexcept
     utility/noreturn
     utility/nullptr

--- a/tests/utility/make_unique.cpp
+++ b/tests/utility/make_unique.cpp
@@ -1,0 +1,115 @@
+/*
+Copyright (c) 2014 Artem Sokolov <derikon@yandex.ru>
+Copyright (c) 2011-2014 Other contributors as noted in the AUTHORS file.
+
+This file is part of Kora.
+
+Kora is free software; you can redistribute it and/or modify
+it under the terms of the GNU Lesser General Public License as published by
+the Free Software Foundation; either version 3 of the License, or
+(at your option) any later version.
+
+Kora is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+GNU Lesser General Public License for more details.
+
+You should have received a copy of the GNU Lesser General Public License
+along with this program. If not, see <http://www.gnu.org/licenses/>.
+*/
+
+#include <gtest/gtest.h>
+
+#include "kora/utility/make_unique.hpp"
+#include "kora/utility/sfinae.hpp"
+
+namespace {
+
+struct a_t {
+    a_t() : x(0), y(0) { }
+    a_t(int x_) : x(x_), y(0) { }
+    a_t(int x_, int y_) : x(x_), y(y_) { }
+
+    int x;
+    int y;
+};
+
+template<typename T, typename = void>
+struct can_create_unique_ptr : std::false_type
+{ };
+
+template<typename T>
+struct can_create_unique_ptr<T,
+    typename kora::requires_type<decltype(kora::make_unique<T>(0))>::type> : std::true_type
+{ };
+
+template<typename T>
+struct stub {
+};
+
+enum unique_ptr_version_tag {
+    single_object_version,
+    array_version
+};
+
+template<typename T>
+unique_ptr_version_tag
+unique_ptr_version(T& t, stub<decltype(*t)> * = 0) {
+    (void) t;
+    return single_object_version;
+}
+
+template<typename T>
+unique_ptr_version_tag
+unique_ptr_version(T& t, stub<decltype(t[0])> * = 0) {
+    (void) t;
+    return array_version;
+}
+
+} // namespace
+
+TEST(MakeUnique, Creation) {
+    EXPECT_EQ(can_create_unique_ptr<a_t>::value, true);
+    EXPECT_EQ(can_create_unique_ptr<a_t[]>::value, true);
+    EXPECT_EQ(can_create_unique_ptr<a_t[5]>::value, false);
+}
+
+TEST(MakeUnique, CorrectUnique) {
+    {
+        auto a = kora::make_unique<a_t>();
+        EXPECT_EQ(unique_ptr_version(a), single_object_version);
+    }
+
+    {
+        auto a = kora::make_unique<a_t[]>(1);
+        EXPECT_EQ(unique_ptr_version(a), array_version);
+    }
+}
+
+TEST(MakeUnique, UniqueObject) {
+    {
+        auto a = kora::make_unique<a_t>();
+        EXPECT_EQ(a->x, 0);
+        EXPECT_EQ(a->y, 0);
+    }
+
+    {
+        auto a = kora::make_unique<a_t>(42);
+        EXPECT_EQ(a->x, 42);
+        EXPECT_EQ(a->y, 0);
+    }
+
+    {
+        auto a = kora::make_unique<a_t>(42, 34);
+        EXPECT_EQ(a->x, 42);
+        EXPECT_EQ(a->y, 34);
+    }
+}
+
+TEST(MakeUnique, UniqueArray) {
+    {
+        auto a = kora::make_unique<a_t[]>(5);
+        EXPECT_EQ(a[1].x, 0);
+    }
+}
+

--- a/tests/utility/make_unique.cpp
+++ b/tests/utility/make_unique.cpp
@@ -25,10 +25,10 @@ along with this program. If not, see <http://www.gnu.org/licenses/>.
 
 namespace {
 
-struct a_t {
-    a_t() : x(0), y(0) { }
-    a_t(int x_) : x(x_), y(0) { }
-    a_t(int x_, int y_) : x(x_), y(y_) { }
+struct test_struct_t {
+    test_struct_t() : x(0), y(0) { }
+    test_struct_t(int x_) : x(x_), y(0) { }
+    test_struct_t(int x_, int y_) : x(x_), y(y_) { }
 
     int x;
     int y;
@@ -68,47 +68,47 @@ unique_ptr_version(T& t, stub<decltype(t[0])> * = 0) {
 
 } // namespace
 
-TEST(MakeUnique, Creation) {
-    EXPECT_EQ(can_create_unique_ptr<a_t>::value, true);
-    EXPECT_EQ(can_create_unique_ptr<a_t[]>::value, true);
-    EXPECT_EQ(can_create_unique_ptr<a_t[5]>::value, false);
+TEST(MakeUnique, TheAbilityToCreate) {
+    EXPECT_EQ(can_create_unique_ptr<test_struct_t>::value, true);
+    EXPECT_EQ(can_create_unique_ptr<test_struct_t[]>::value, true);
+    EXPECT_EQ(can_create_unique_ptr<test_struct_t[5]>::value, false);
 }
 
-TEST(MakeUnique, CorrectUnique) {
+TEST(MakeUnique, CorrectUniquePtrVersion) {
     {
-        auto a = kora::make_unique<a_t>();
+        auto a = kora::make_unique<test_struct_t>();
         EXPECT_EQ(unique_ptr_version(a), single_object_version);
     }
 
     {
-        auto a = kora::make_unique<a_t[]>(1);
+        auto a = kora::make_unique<test_struct_t[]>(1);
         EXPECT_EQ(unique_ptr_version(a), array_version);
     }
 }
 
-TEST(MakeUnique, UniqueObject) {
+TEST(MakeUnique, UniquePtrSingleObjectVersion) {
     {
-        auto a = kora::make_unique<a_t>();
+        auto a = kora::make_unique<test_struct_t>();
         EXPECT_EQ(a->x, 0);
         EXPECT_EQ(a->y, 0);
     }
 
     {
-        auto a = kora::make_unique<a_t>(42);
+        auto a = kora::make_unique<test_struct_t>(42);
         EXPECT_EQ(a->x, 42);
         EXPECT_EQ(a->y, 0);
     }
 
     {
-        auto a = kora::make_unique<a_t>(42, 34);
+        auto a = kora::make_unique<test_struct_t>(42, 34);
         EXPECT_EQ(a->x, 42);
         EXPECT_EQ(a->y, 34);
     }
 }
 
-TEST(MakeUnique, UniqueArray) {
+TEST(MakeUnique, UniquePtrArrayVersion) {
     {
-        auto a = kora::make_unique<a_t[]>(5);
+        auto a = kora::make_unique<test_struct_t[]>(5);
         EXPECT_EQ(a[1].x, 0);
     }
 }

--- a/tests/utility/make_unique.cpp
+++ b/tests/utility/make_unique.cpp
@@ -74,6 +74,18 @@ TEST(MakeUnique, TheAbilityToCreate) {
     EXPECT_EQ(can_create_unique_ptr<test_struct_t[5]>::value, false);
 }
 
+TEST(MakeUnique, CreatingOfUniquePtr) {
+	{
+		auto a = kora::make_unique<test_struct_t>();
+		EXPECT_EQ(static_cast<bool>(a), true);
+	}
+
+	{
+		auto a = kora::make_unique<test_struct_t[]>(5);
+		EXPECT_EQ(static_cast<bool>(a), true);
+	}
+}
+
 TEST(MakeUnique, CorrectUniquePtrVersion) {
     {
         auto a = kora::make_unique<test_struct_t>();


### PR DESCRIPTION
The PR adds make_unique as it described in Working Draft of Standard for Programming Language C++ Document Number: N4296, Date: 2014-11-19, Revises: N4140.

