### PR TITLE
feature(dynamic): make object_t::at method and rvalues friends

### DIFF
--- a/include/kora/dynamic/object.hpp
+++ b/include/kora/dynamic/object.hpp
@@ -98,6 +98,16 @@ public:
     const dynamic_t&
     at(const std::string& key, const dynamic_t& default_) const KORA_NOEXCEPT;
 
+    /*! Get the copy of value by key if it exists in the collection, default value otherwise.
+     *
+     * \param[in] key The key to search in the object.
+     * \param[in] default_ The rvalue to return in case if the object doesn't contain the key.
+     * \returns Value stored by the key or \p default_ if the object doesn't contain the key.
+     */
+    KORA_API
+    dynamic_t
+    at(const std::string& key, dynamic_t&& default_) const;
+
     using base_type::operator[];
 
     /*! Get value by key.

--- a/src/dynamic/object.cpp
+++ b/src/dynamic/object.cpp
@@ -44,6 +44,17 @@ dynamic_t::object_t::at(const std::string& key, const dynamic_t& default_) const
     }
 }
 
+dynamic_t
+dynamic_t::object_t::at(const std::string& key, dynamic_t&& default_) const {
+    const auto it = find(key);
+
+    if (it == end()) {
+        return default_;
+    } else {
+        return it->second;
+    }
+}
+
 const dynamic_t&
 dynamic_t::object_t::operator[](const std::string& key) const {
     return at(key);

--- a/tests/dynamic/object.cpp
+++ b/tests/dynamic/object.cpp
@@ -99,3 +99,12 @@ TEST(DynamicObject, Indexing) {
     EXPECT_EQ(5, const_obj["key"]);
     ASSERT_THROW(const_obj["key2"], std::out_of_range);
 }
+
+TEST(DynamicObject, AtRvalue) {
+    kora::dynamic_t::object_t obj1;
+    obj1["key"] = 5;
+
+    const auto& obj2 = obj1.at("unknown", kora::dynamic_t::object_t());
+
+    EXPECT_EQ(kora::dynamic_t::object_t(), obj2);
+}


### PR DESCRIPTION
This commit allows to use rvalues as a default parameter for `at` method. It saves from the common mistake, where you want to obtain reference to the object in map if it exists, or default value otherwise:

```
const auto& obj2 = obj1.at("unknown", kora::dynamic_t::object_t());
```

Without this patch the given line will probably crash.

@iderikon @andrusha97 PTAL